### PR TITLE
POD-2111: Update EGA file pre-validation

### DIFF
--- a/scripts/encrypt_data_file.py
+++ b/scripts/encrypt_data_file.py
@@ -23,6 +23,7 @@ def encrypt_file(aggregation_path, crypt4gh_encryption_key):
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"Error encrypting file: {e.stderr.decode()}") from e
 
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description="Encrypt the given data file using crypt4gh"

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -37,8 +37,10 @@ class LoggingConfigurator:
         # Set the level of the root logger to INFO
         root_logger.setLevel(logging.INFO)
 
+
 # Instantiate LoggingConfigurator when this module is imported
 logging_configurator = LoggingConfigurator()
+
 
 class LoginAndGetToken:
     def __init__(self, username: str, password: str) -> None:
@@ -98,6 +100,7 @@ def get_file_metadata_for_all_files_in_inbox(headers: dict) -> Optional[list[dic
                  attempting to query for file metadata"""
         logging.error(error_message)
         raise Exception(error_message)
+
 
 def normalize_sample_alias(sample_alias):
     """


### PR DESCRIPTION
[POD-2111](https://broadinstitute.atlassian.net/browse/POD-2111): Update EGA file pre-validation

Changes include: 
* Remove the file pre-validation: We no longer prevent duplicate files from being uploaded. This is the workaround to upload files that may have previously been corrupted (since we can't delete files from the inbox) 
* Also check that the status of the file is a valid one (the status must be `inbox`) and that there are no errors linked to the file 
* We still only select one file to associate with the run, even if there are multiple copies of the same file in the inbox 

[POD-2111]: https://broadinstitute.atlassian.net/browse/POD-2111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ