### PR TITLE
Add sleep time to file transfer

### DIFF
--- a/scripts/transfer_ega_file.py
+++ b/scripts/transfer_ega_file.py
@@ -2,6 +2,9 @@ import os
 import sys
 import argparse
 import logging
+from random import randint
+from time import sleep
+
 import paramiko
 import subprocess
 sys.path.append("./")
@@ -32,7 +35,9 @@ def get_active_account() -> str:
 
 def transfer_file(encrypted_data_file: str, ega_inbox: str, password: str) -> None:
     """Transfer encrypted data file to EGA inbox via SFTP."""
-    try:    
+    try:
+        # Sleep between 1 and 60 seconds to reduce load on EGA server
+        sleep(randint(1, 60))
         # Establish an SFTP connection
         with paramiko.Transport((SFTP_HOSTNAME, SFTP_PORT)) as transport:
             transport.connect(username=ega_inbox, password=password)


### PR DESCRIPTION
Sleep between 1 and 60 seconds to reduce load on EGA server -- trying this first. If it's insufficient, will implement the more complicated solution of retries with `backoff`.