### PR TITLE
Remove finalization step

### DIFF
--- a/scripts/register_dataset_and_finalize_submission.py
+++ b/scripts/register_dataset_and_finalize_submission.py
@@ -209,7 +209,11 @@ class RegisterEgaDatasetAndFinalizeSubmission:
             dataset_provisional_id = self._conditionally_create_dataset(policy_accession_id)
             # If the dataset gets successfully created, finalize the submission
             if dataset_provisional_id:
-                self._finalize_submission()
+                # self._finalize_submission()
+                logging.info(
+                    "SKIPPING finalization step. "
+                    "Use EGA portal to Finalize submission."
+                )
 
 
 if __name__ == '__main__':

--- a/scripts/register_dataset_and_finalize_submission.py
+++ b/scripts/register_dataset_and_finalize_submission.py
@@ -210,6 +210,7 @@ class RegisterEgaDatasetAndFinalizeSubmission:
             # If the dataset gets successfully created, finalize the submission
             if dataset_provisional_id:
                 # self._finalize_submission()
+                # Finalization through API currently not possible, per EGA
                 logging.info(
                     "SKIPPING finalization step. "
                     "Use EGA portal to Finalize submission."


### PR DESCRIPTION
The finalization step always fails because finalization through the API is currently not possible, per EGA. They don’t have immediate plans to fix this, so I’ve removed this step from the script.