### PR TITLE
Force argparse to treat 'sample_alias' as string

### DIFF
--- a/scripts/check_file_validation_status.py
+++ b/scripts/check_file_validation_status.py
@@ -117,7 +117,8 @@ if __name__ == '__main__':
     parser.add_argument(
         "-sample_alias",
         required=True,
-        help="The sample alias to register metadata for"
+        type=str,
+        help="The sample alias to register metadata for",
     )
     parser.add_argument(
         "-sample_id",

--- a/scripts/register_experiment_and_run_metadata.py
+++ b/scripts/register_experiment_and_run_metadata.py
@@ -411,7 +411,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "-sample_alias",
         required=True,
-        help="The sample alias to register metadata for"
+        type=str,
+        help="The sample alias to register metadata for",
     )
     parser.add_argument(
         "-sample_id",

--- a/scripts/transfer_ega_file.py
+++ b/scripts/transfer_ega_file.py
@@ -2,8 +2,6 @@ import os
 import sys
 import argparse
 import logging
-from random import randint
-from time import sleep
 
 import paramiko
 import subprocess
@@ -36,8 +34,6 @@ def get_active_account() -> str:
 def transfer_file(encrypted_data_file: str, ega_inbox: str, password: str) -> None:
     """Transfer encrypted data file to EGA inbox via SFTP."""
     try:
-        # Sleep between 1 and 60 seconds to reduce load on EGA server
-        sleep(randint(1, 60))
         # Establish an SFTP connection
         with paramiko.Transport((SFTP_HOSTNAME, SFTP_PORT)) as transport:
             transport.connect(username=ega_inbox, password=password)


### PR DESCRIPTION
Certain samples have aliases beginning with `00`. These are being dropped by argparse. Added `type=str` to 'sample_alias' argument to force the value to be a str.