### PR TITLE
Study provisional IDs

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -3,6 +3,9 @@ workflows:
   - name: registerEGAExperimentAndRuns
     subclass: WDL
     primaryDescriptorPath: /workflows/RegisterEGAExperimentAndRun/RegisterEGAExperimentAndRun.wdl
+  - name: registerEGAExperimentAndRunProvisionalStudyID
+    subclass: WDL
+    primaryDescriptorPath: /workflows/RegisterEGAExperimentAndRunProvisionalStudyID/RegisterEGAExperimentAndRunProvisionalStudyID.wdl
   - name: registerEGADataset
     subclass: WDL
     primaryDescriptorPath: /workflows/RegisterEGADatasetFinalizeSubmission/RegisterEGADatasetFinalizeSubmission.wdl

--- a/README.md
+++ b/README.md
@@ -36,18 +36,19 @@ In order to push changes to the Python code to GCR, you'll need the `gcloud` CLI
 ### Script Updates
 All Python code is contained in a Docker image, which is stored in Google Container Registry. The Terra workflows then pull these Docker images in the WDLs.
 With every change to the Python code, you will need to rebuild and push the Docker image. You will need write access to the Container Registry in the `sc-ega-submissions` project. Reach out to Sam Bryant if you need these permissions.
+
+- If you're not already logged in via gcloud, you will have to run `gcloud auth login` first and login via your Broad account. See directions [here](https://cloud.google.com/sdk/docs/install) for installing the gcloud CLI. See directions [here](https://cloud.google.com/docs/authentication/gcloud) for authenticating with gcloud.
+- If you've not already configured Docker to work with the gcloud CLI, run `gcloud auth configure-docker us-east1-docker.pkg.dev` to ensure authentication. See [here](https://cloud.google.com/artifact-registry/docs/docker/authentication#gcloud-helper) for more information. 
+
 To rebuild and push the Docker images, run the [docker_build.sh](docker_build.sh) script from the root of the repository: 
 ```commandline
 ./docker_build.sh
 ```
 
-- If you're not already logged in via gcloud, you will have to run `gcloud auth login` first and login via your Broad account. See directions [here](https://cloud.google.com/sdk/docs/install) for installing the gcloud CLI. See directions [here](https://cloud.google.com/docs/authentication/gcloud) for authenticating with gcloud.
-- If you've not already configured Docker to work with the gcloud CLI, run `gcloud auth configure-docker us-east1-docker.pkg.dev` to ensure authentication. See [here](https://cloud.google.com/artifact-registry/docs/docker/authentication#gcloud-helper) for more information. 
-
 Sometimes, it is helpful to view the contents of the Docker image. To do this, we can simply SSH into the image:
 ```bash
-docker pull gcr.io/gdc-submissions/ega-submission-scripts:1.0.0
-docker run -it gcr.io/gdc-submissions/ega-submission-scripts:1.0.0
+docker pull docker pull us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-<tag>
+docker run -it us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-<tag>
 ```
 
 Once you've built and pushed your Docker image, you'll have to find the Docker tag and update all the WDL workflows to use the new tag. You'll see the new Docker tag in the output of the console when you build the image. 

--- a/scripts/check_file_validation_status.py
+++ b/scripts/check_file_validation_status.py
@@ -19,10 +19,9 @@ from scripts.utils import (
 class GetValidationStatus:
     VALID_STATUS_CODES = [200, 201]
 
-    def __init__(self, token: str, sample_alias: str, submission_accession_id: str) -> None:
+    def __init__(self, token: str, sample_alias: str) -> None:
         self.token = token
         self.sample_alias = sample_alias
-        self.submission_accession_id = submission_accession_id
 
     def _headers(self):
         return format_request_header(self.token)
@@ -109,11 +108,6 @@ if __name__ == '__main__':
                     " the metadata into the Terra tables"
     )
     parser.add_argument(
-        "-submission_accession_id",
-        required=True,
-        help="The submission accession ID"
-    )
-    parser.add_argument(
         "-user_name",
         required=True,
         help="The EGA username"
@@ -138,8 +132,7 @@ if __name__ == '__main__':
         logging.info("Successfully generated access token")
         validation_status = GetValidationStatus(
             token=access_token,
-            sample_alias=args.sample_alias,
-            submission_accession_id=args.submission_accession_id
+            sample_alias=args.sample_alias
         ).get_file_validation_status()
 
         WriteOutputTsvFiles(

--- a/workflows/EGAFileTransfer/EGAFileTransfer.wdl
+++ b/workflows/EGAFileTransfer/EGAFileTransfer.wdl
@@ -37,7 +37,7 @@ task EncryptDataFiles {
 
     runtime {
         memory: "30 GB"
-        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1725389492"
+        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1737755449"
         cpu: 2
         disks: "local-disk " + disk_size + " HDD"
     }
@@ -64,7 +64,7 @@ task InboxFileTransfer {
 
     runtime {
         memory: "30 GB"
-        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1725389492"
+        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1737755449"
         cpu: 2
         disks: "local-disk " + disk_size + " HDD"
     }

--- a/workflows/RegisterEGADatasetFinalizeSubmission/RegisterEGADatasetFinalizeSubmission.wdl
+++ b/workflows/RegisterEGADatasetFinalizeSubmission/RegisterEGADatasetFinalizeSubmission.wdl
@@ -53,6 +53,6 @@ task RegisterDatasetFinalizeSubmission {
 
     runtime {
         preemptible: 3
-        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1725389492"
+        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1737755449"
     }
 }

--- a/workflows/RegisterEGAExperimentAndRun/RegisterEGAExperimentAndRun.wdl
+++ b/workflows/RegisterEGAExperimentAndRun/RegisterEGAExperimentAndRun.wdl
@@ -27,7 +27,6 @@ workflow RegisterEGAExperimentAndRun {
     # Check the file status
     call CheckEGAFileValidationStatus {
         input:
-            submission_accession_id = submission_accession_id,
             ega_inbox = ega_inbox,
             sample_alias = sample_alias,
             sample_id = sample_id
@@ -137,7 +136,6 @@ task RegisterExperimentAndRun{
 
 task CheckEGAFileValidationStatus {
     input {
-        String submission_accession_id
         String ega_inbox
         String sample_alias
         String sample_id
@@ -145,7 +143,6 @@ task CheckEGAFileValidationStatus {
 
     command {
         python3 /scripts/check_file_validation_status.py \
-            -submission_accession_id ~{submission_accession_id} \
             -user_name ~{ega_inbox} \
             -sample_alias "~{sample_alias}" \
             -sample_id ~{sample_id} \

--- a/workflows/RegisterEGAExperimentAndRun/RegisterEGAExperimentAndRun.wdl
+++ b/workflows/RegisterEGAExperimentAndRun/RegisterEGAExperimentAndRun.wdl
@@ -124,7 +124,7 @@ task RegisterExperimentAndRun{
     }
 
     runtime {
-        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1725389492"
+        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1737755449"
     }
 
     output {
@@ -148,7 +148,7 @@ task CheckEGAFileValidationStatus {
 
     runtime {
         preemptible: 3
-        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1725389492"
+        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1737755449"
     }
 
     output {
@@ -172,7 +172,7 @@ task DeleteFileFromBucket {
 
     runtime {
         preemptible: 3
-        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1725389492"
+        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1737755449"
     }
 }
 
@@ -201,7 +201,7 @@ task UpsertMetadataToDataModel {
 
     runtime {
         preemptible: 3
-        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1725389492"
+        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1737755449"
     }
 
     output {

--- a/workflows/RegisterEGAExperimentAndRun/RegisterEGAExperimentAndRun.wdl
+++ b/workflows/RegisterEGAExperimentAndRun/RegisterEGAExperimentAndRun.wdl
@@ -4,7 +4,7 @@ workflow RegisterEGAExperimentAndRun {
     input {
         String workspace_name
         String workspace_project
-        String submission_accession_id
+        String submission_accession_or_provisional_id
         String study_accession_id
         String ega_inbox
         String illumina_instrument
@@ -45,7 +45,7 @@ workflow RegisterEGAExperimentAndRun {
 
         call RegisterExperimentAndRun {
             input:
-                submission_accession_id = submission_accession_id,
+                submission_accession_or_provisional_id = submission_accession_or_provisional_id,
                 study_accession_id = study_accession_id,
                 ega_inbox = ega_inbox,
                 illumina_instrument = illumina_instrument,
@@ -84,7 +84,7 @@ workflow RegisterEGAExperimentAndRun {
 
 task RegisterExperimentAndRun{
     input {
-        String submission_accession_id
+        String submission_accession_or_provisional_id
         String study_accession_id
         String ega_inbox
         String illumina_instrument
@@ -104,7 +104,7 @@ task RegisterExperimentAndRun{
 
     command {
         python3 /scripts/register_experiment_and_run_metadata.py \
-            -submission_accession_id ~{submission_accession_id} \
+            -submission_accession_or_provisional_id ~{submission_accession_or_provisional_id} \
             -study_accession_id ~{study_accession_id} \
             -user_name ~{ega_inbox} \
             -instrument_model ~{illumina_instrument} \
@@ -112,8 +112,6 @@ task RegisterExperimentAndRun{
             -library_strategy ~{library_strategy} \
             -library_source ~{library_source} \
             -library_selection "~{library_selection}" \
-            -run_file_type ~{run_file_type} \
-            -run_file_type ~{run_file_type} \
             -technology ILLUMINA \
             -run_file_type ~{run_file_type} \
             -sample_alias "~{sample_alias}" \
@@ -122,7 +120,7 @@ task RegisterExperimentAndRun{
             -mean_insert_size ~{avg_mean_insert_size} \
             -standard_deviation ~{avg_standard_deviation} \
             -sample_material_type "~{sample_material_type}" \
-            -construction_protocol "~{construction_protocol}" \
+            -construction_protocol "~{construction_protocol}"
     }
 
     runtime {

--- a/workflows/RegisterEGAExperimentAndRunProvisionalStudyID/RegisterEGAExperimentAndRunProvisionalStudyID.wdl
+++ b/workflows/RegisterEGAExperimentAndRunProvisionalStudyID/RegisterEGAExperimentAndRunProvisionalStudyID.wdl
@@ -1,0 +1,210 @@
+version 1.0
+
+workflow RegisterEGAExperimentAndRun {
+    input {
+        String workspace_name
+        String workspace_project
+        String submission_accession_or_provisional_id
+        String study_provisional_id
+        String ega_inbox
+        String illumina_instrument
+        String library_layout
+        String library_strategy
+        String library_source
+        String library_selection
+        String run_file_type
+        String sample_alias
+        String sample_id
+        String group_library_name
+        Float avg_mean_insert_size
+        Float avg_standard_deviation
+        String sample_material_type
+        String construction_protocol
+        String aggregation_path
+        Boolean delete_files = false
+    }
+
+    # Check the file status
+    call CheckEGAFileValidationStatus {
+        input:
+            ega_inbox = ega_inbox,
+            sample_alias = sample_alias,
+            sample_id = sample_id
+    }
+
+    # Write the validation status to the Terra data tables
+    call UpsertMetadataToDataModel as UpsertFileValidation {
+        input:
+            workspace_name = workspace_name,
+            workspace_project = workspace_project,
+            tsv = CheckEGAFileValidationStatus.sample_id_validation_status_tsv
+    }
+
+    # Check the validation status and only continue to registering the metadata if the file is valid
+    if (CheckEGAFileValidationStatus.validation_status == "validated") {
+
+        call RegisterExperimentAndRun {
+            input:
+                submission_accession_or_provisional_id = submission_accession_or_provisional_id,
+                study_provisional_id = study_provisional_id,
+                ega_inbox = ega_inbox,
+                illumina_instrument = illumina_instrument,
+                library_layout = library_layout,
+                library_strategy = library_strategy,
+                library_source = library_source,
+                library_selection = library_selection,
+                run_file_type = run_file_type,
+                sample_alias = sample_alias,
+                sample_id = sample_id,
+                group_library_name = group_library_name,
+                avg_mean_insert_size = avg_mean_insert_size,
+                avg_standard_deviation = avg_standard_deviation,
+                sample_material_type = sample_material_type,
+                construction_protocol = construction_protocol
+        }
+
+        call UpsertMetadataToDataModel as UpsertRunProvisionalId{
+            input:
+                workspace_name = workspace_name,
+                workspace_project = workspace_project,
+                tsv = RegisterExperimentAndRun.run_provisional_tsv
+        }
+
+        # If delete_files is set to true, proceed with deleting the cram/crai/md5 from the Terra bucket
+        if (delete_files) {
+
+            call DeleteFileFromBucket {
+                input:
+                    aggregation_path = aggregation_path
+            }
+        }
+    }
+}
+
+
+task RegisterExperimentAndRun{
+    input {
+        String submission_accession_or_provisional_id
+        String study_provisional_id
+        String ega_inbox
+        String illumina_instrument
+        String library_layout
+        String library_strategy
+        String library_source
+        String library_selection
+        String run_file_type
+        String sample_alias
+        String sample_id
+        String group_library_name
+        Float avg_mean_insert_size
+        Float avg_standard_deviation
+        String sample_material_type
+        String construction_protocol
+    }
+
+    command {
+        python3 /scripts/register_experiment_and_run_metadata.py \
+            -submission_accession_or_provisional_id ~{submission_accession_or_provisional_id} \
+            -study_provisional_id ~{study_provisional_id} \
+            -user_name ~{ega_inbox} \
+            -instrument_model ~{illumina_instrument} \
+            -library_layout ~{library_layout} \
+            -library_strategy ~{library_strategy} \
+            -library_source ~{library_source} \
+            -library_selection "~{library_selection}" \
+            -technology ILLUMINA \
+            -run_file_type ~{run_file_type} \
+            -sample_alias "~{sample_alias}" \
+            -sample_id ~{sample_id} \
+            -library_name ~{group_library_name} \
+            -mean_insert_size ~{avg_mean_insert_size} \
+            -standard_deviation ~{avg_standard_deviation} \
+            -sample_material_type "~{sample_material_type}" \
+            -construction_protocol "~{construction_protocol}"
+    }
+
+    runtime {
+        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1737755449"
+    }
+
+    output {
+        File run_provisional_tsv = "sample_id_and_run_provisional_id.tsv"
+    }
+}
+
+task CheckEGAFileValidationStatus {
+    input {
+        String ega_inbox
+        String sample_alias
+        String sample_id
+    }
+
+    command {
+        python3 /scripts/check_file_validation_status.py \
+            -user_name ~{ega_inbox} \
+            -sample_alias "~{sample_alias}" \
+            -sample_id ~{sample_id} \
+    }
+
+    runtime {
+        preemptible: 3
+        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1737755449"
+    }
+
+    output {
+        String validation_status = read_string("file_validation_status.tsv")
+        File sample_id_validation_status_tsv = "sample_id_validation_status.tsv"
+    }
+}
+
+task DeleteFileFromBucket {
+    input {
+        String aggregation_path
+    }
+
+    String aggregation_md5_path  = aggregation_path + ".md5"
+
+    command <<<
+        set -eo pipefail
+        gsutil rm -a ~{aggregation_path}
+        gsutil rm -a ~{aggregation_md5_path}
+    >>>
+
+    runtime {
+        preemptible: 3
+        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1737755449"
+    }
+}
+
+task UpsertMetadataToDataModel {
+    input {
+        # workspace details
+        String workspace_name
+        String workspace_project
+    
+        # load file with sample metadata to ingest to table
+        File   tsv
+    }
+
+    parameter_meta {
+        workspace_name: "Name of the workspace to which WDL should push the additional sample metadata."
+        workspace_project: "Namespace/project of workspace to which WDL should push the additional sample metadata."
+        tsv: "Load tsv file formatted in the Terra required format to update the sample table."
+    }
+
+    command {
+        set -eo pipefail
+        python3 /scripts/batch_upsert_entities.py -w ~{workspace_name} \
+                                                      -p ~{workspace_project} \
+                                                      -t ~{tsv}
+    }
+
+    runtime {
+        preemptible: 3
+        docker: "us-east1-docker.pkg.dev/sc-ega-submissions/ega-submission-scripts/python-scripts:0.0.1-1737755449"
+    }
+
+    output {
+        File ingest_logs = stdout()
+    }
+}


### PR DESCRIPTION
Adds to scripts and a new workflow the ability to use `study_provisional_id` instead of `study_accession_id`, when necessary.

Removes `submission_accession_id` parameter from `CheckEGAFileValidationStatus` since it is unused.

Clarifies that `submission_accession_id` may be EITHER and accession ID or provisional ID by renaming to `submission_accession_or_provisional_id`.

Makes minor updates to README.